### PR TITLE
Updates for generating the 0.8.3 AppImage.

### DIFF
--- a/appimage/Dockerfile
+++ b/appimage/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 RUN apt-get update; apt-get upgrade -y
 RUN apt-get install -y autoconf \
@@ -6,10 +6,12 @@ RUN apt-get install -y autoconf \
                        fuse \
                        gettext \
                        libboost-all-dev \
+                       libevent-dev \
                        libminiupnpc-dev \
                        libssl-dev \
                        libtool \
                        pkg-config \
+                       protobuf-compiler \
                        qtbase5-dev \
                        qttools5-dev-tools
 

--- a/appimage/README.md
+++ b/appimage/README.md
@@ -11,7 +11,7 @@ make
 
 For a tag:
 ```
-make TAG=v0.7.1ppc
+make TAG=v0.8.3ppc
 ```
 
 `Peercoin-x86_64.AppImage` is deposited in the `/build` directory.


### PR DESCRIPTION
I updated the AppImage for 0.8.3 :tada: 

It can be downloaded from: https://files.peercoin.net/download/Peercoin-x86_64.AppImage

I started using it as my main client... seems to be working as expected :)